### PR TITLE
Fr friends

### DIFF
--- a/app/controllers/friends_controller.rb
+++ b/app/controllers/friends_controller.rb
@@ -1,0 +1,5 @@
+class FriendsController < ApplicationController
+  def create
+    binding.pry
+  end
+end

--- a/app/controllers/friends_controller.rb
+++ b/app/controllers/friends_controller.rb
@@ -1,5 +1,9 @@
 class FriendsController < ApplicationController
   def create
     current_user.add_friend(params["login"])
+    flash[:success] = "Successfully Added Friend!"
+    current_user.reload
+
+    redirect_to dashboard_path
   end
 end

--- a/app/controllers/friends_controller.rb
+++ b/app/controllers/friends_controller.rb
@@ -1,5 +1,5 @@
 class FriendsController < ApplicationController
   def create
-    binding.pry
+    current_user.add_friend(params["login"])
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -16,8 +16,8 @@ class SessionsController < ApplicationController
 
   def update
     user_info = request.env['omniauth.auth']
-    binding.pry
     current_user.update_column(:token, user_info[:credentials][:token])
+    current_user.update_column(:login, user_info[:extra][:raw_info][:login])
     redirect_to '/dashboard'
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -16,6 +16,7 @@ class SessionsController < ApplicationController
 
   def update
     user_info = request.env['omniauth.auth']
+    binding.pry
     current_user.update_column(:token, user_info[:credentials][:token])
     redirect_to '/dashboard'
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   def show
+      @all_friends = current_user.load_friends if current_user
   end
 
   def new

--- a/app/models/friend.rb
+++ b/app/models/friend.rb
@@ -1,0 +1,4 @@
+class Friend < ApplicationRecord
+  belongs_to :user
+  belongs_to :user_friend, class_name: 'User'
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,6 +42,8 @@ class User < ApplicationRecord
   end
 
   def add_friend(friends_username)
-    binding.pry
+    friend = User.find_by(login: friends_username)
+    Friend.create(user_id: id, user_friend_id: friend.id)
+    Friend.create(user_id: friend.id, user_friend_id: id)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,4 +38,8 @@ class User < ApplicationRecord
   def self.has_account?(followers_name)
     User.find_by(login: followers_name)
   end
+
+  def add_friend(friends_username)
+    binding.pry
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -58,4 +58,13 @@ class User < ApplicationRecord
       end
     true
   end
+
+  def load_friends
+    unless self.friends.length == 0
+      all_friends = self.friends.map do |friend|
+        User.find(friend.user_friend_id)
+      end
+    return all_friends
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,4 +34,8 @@ class User < ApplicationRecord
     @all_following = search.following
     @all_following
   end
+
+  def has_account?(followers_email)
+    User.find_by(email: followers_email)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,4 +46,16 @@ class User < ApplicationRecord
     Friend.create(user_id: id, user_friend_id: friend.id)
     Friend.create(user_id: friend.id, user_friend_id: id)
   end
+
+  def valid_friend?(potential_friend)
+    new_friend = User.find_by(login: potential_friend.name)
+      if self.friends.length == 0
+        true
+      else
+        self.friends.each do |current_friend|
+          return false if current_friend.user_friend_id == new_friend.id
+        end
+      end
+    true
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,7 +35,7 @@ class User < ApplicationRecord
     @all_following
   end
 
-  def has_account?(followers_email)
-    User.find_by(email: followers_email)
+  def self.has_account?(followers_name)
+    User.find_by(login: followers_name)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ApplicationRecord
   has_many :user_videos, dependent: :destroy
   has_many :videos, through: :user_videos
+  has_many :friends, dependent: :destroy
+  has_many :user_friends, through: :friends
   validates :email, uniqueness: true, presence: true
   validates :password, presence: true
   validates :first_name, presence: true

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -51,7 +51,7 @@
     <% if current_user.friends.length != 0%>
     <h4>My Friends</h4>
       <%@all_friends.each do |friend| %>
-        <p><%=friend.first_name%> <%=friend.last_name%></p>
+        <p><%=friend.first_name%> <%=friend.last_name%> aka <%=friend.login%></p>
       <%end%>
     <%end%>
   </section>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -30,7 +30,9 @@
       <h4>Followers</h4>
       <% current_user.all_followers(current_user.token).each do |follower| %>
         <p class="follower-name"><%= link_to follower.name, follower.html_url %></p>
-        
+        <% if current_user.token != "No Key" && !User.has_account?(follower.name).nil?%>
+            <%= link_to "Add as Friend", "/friends/new", method: 'post'%>
+        <%end%>
     <%end%>
     </section><br>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -47,4 +47,12 @@
     </section>
   </section>
   <% end %>
+  <section class="my_friends">
+    <% if current_user.friends.length != 0%>
+    <h4>My Friends</h4>
+      <%@all_friends.each do |friend| %>
+        <p><%=friend.first_name%> <%=friend.last_name%></p>
+      <%end%>
+    <%end%>
+  </section>
 </section>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -30,7 +30,7 @@
       <h4>Followers</h4>
       <% current_user.all_followers(current_user.token).each do |follower| %>
         <p class="follower-name"><%= link_to follower.name, follower.html_url %></p>
-        <% if current_user.token != "No Key" && !User.has_account?(follower.name).nil?%>
+        <% if current_user.token != "No Key" && !User.has_account?(follower.name).nil? && current_user.valid_friend?(follower)%>
             <%= link_to "Add as Friend", friends_new_path(:login => "#{follower.name}"), method: 'post'%>
         <%end%>
     <%end%>
@@ -40,6 +40,9 @@
       <h4>Following</h4>
       <% current_user.all_following(current_user.token).each do |following| %>
         <p class="following-name"><%= link_to following.name, following.html_url %></p>
+        <% if current_user.token != "No Key" && !User.has_account?(following.name).nil? && current_user.valid_friend?(following)%>
+            <%= link_to "Add as Friend", friends_new_path(:login => "#{following.name}"), method: 'post'%>
+        <%end%>
       <% end %>
     </section>
   </section>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -31,7 +31,7 @@
       <% current_user.all_followers(current_user.token).each do |follower| %>
         <p class="follower-name"><%= link_to follower.name, follower.html_url %></p>
         <% if current_user.token != "No Key" && !User.has_account?(follower.name).nil?%>
-            <%= link_to "Add as Friend", "/friends/new", method: 'post'%>
+            <%= link_to "Add as Friend", friends_new_path(:login => "#{follower.name}"), method: 'post'%>
         <%end%>
     <%end%>
     </section><br>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -30,7 +30,8 @@
       <h4>Followers</h4>
       <% current_user.all_followers.each do |follower| %>
         <p class="follower-name"><%= link_to follower.name, follower.html_url %></p>
-      <% end %>
+        
+    <%end%>
     </section><br>
 
     <section class="following">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,7 @@ Rails.application.routes.draw do
   get '/video', to: 'video#show'
 
   resources :users, only: [:new, :create, :update, :edit]
+  post '/friends/new', to: 'friends#create'
 
   resources :tutorials, only: [:show, :index] do
     resources :videos, only: [:show, :index]

--- a/db/migrate/20200511204319_add_login_to_users.rb
+++ b/db/migrate/20200511204319_add_login_to_users.rb
@@ -1,0 +1,5 @@
+class AddLoginToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :login, :string
+  end
+end

--- a/db/migrate/20200511204319_add_login_to_users.rb
+++ b/db/migrate/20200511204319_add_login_to_users.rb
@@ -1,5 +1,5 @@
 class AddLoginToUsers < ActiveRecord::Migration[5.2]
   def change
-    add_column :users, :login, :string
+    add_column :users, :login, :string, :default => "No Login"
   end
 end

--- a/db/migrate/20200512183355_create_friends.rb
+++ b/db/migrate/20200512183355_create_friends.rb
@@ -1,0 +1,10 @@
+class CreateFriends < ActiveRecord::Migration[5.2]
+  def change
+    create_table :friends do |t|
+      t.belongs_to :user, foreign_key: true
+      t.belongs_to :user_friend
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -77,7 +77,7 @@ ActiveRecord::Schema.define(version: 2020_05_12_183355) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "token", default: "No Key"
-    t.string "login"
+    t.string "login", default: "No Login"
     t.index ["email"], name: "index_users_on_email"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_11_204319) do
+ActiveRecord::Schema.define(version: 2020_05_12_183355) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "friends", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "user_friend_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_friend_id"], name: "index_friends_on_user_friend_id"
+    t.index ["user_id"], name: "index_friends_on_user_id"
+  end
 
   create_table "taggings", id: :serial, force: :cascade do |t|
     t.integer "tag_id"
@@ -68,7 +77,7 @@ ActiveRecord::Schema.define(version: 2020_05_11_204319) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "token", default: "No Key"
-    t.string "login", default: "No Login"
+    t.string "login"
     t.index ["email"], name: "index_users_on_email"
   end
 
@@ -82,6 +91,7 @@ ActiveRecord::Schema.define(version: 2020_05_11_204319) do
     t.index ["tutorial_id"], name: "index_videos_on_tutorial_id"
   end
 
+  add_foreign_key "friends", "users"
   add_foreign_key "user_videos", "users"
   add_foreign_key "user_videos", "videos"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -68,7 +68,7 @@ ActiveRecord::Schema.define(version: 2020_05_11_204319) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "token", default: "No Key"
-    t.string "login"
+    t.string "login", default: "No Login"
     t.index ["email"], name: "index_users_on_email"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_06_194641) do
+ActiveRecord::Schema.define(version: 2020_05_11_204319) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -68,6 +68,7 @@ ActiveRecord::Schema.define(version: 2020_05_06_194641) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "token", default: "No Key"
+    t.string "login"
     t.index ["email"], name: "index_users_on_email"
   end
 

--- a/spec/features/user/user_can_add_friends_from_followers_spec.rb
+++ b/spec/features/user/user_can_add_friends_from_followers_spec.rb
@@ -29,5 +29,8 @@ describe 'User' do
     visit(dashboard_path)
     expect(page).to have_link("Add as Friend")
     click_link("Add as Friend")
+
+    expect(page).to have_content("Friend Added Succesfully")
+    expect(user1.friends.length).to eq(1)
   end
 end

--- a/spec/features/user/user_can_add_friends_from_followers_spec.rb
+++ b/spec/features/user/user_can_add_friends_from_followers_spec.rb
@@ -1,7 +1,43 @@
 require 'rails_helper'
 
 describe 'User' do
-  it 'user can sign in' do
+  it 'user can add friends from their dashboard' do
+    user_2 = User.create(
+     email: 'fredrondina96@gmail.com',
+     first_name: 'Fred',
+     last_name: 'Rondina',
+     password: 'password_1',
+     login: 'fredrondina96',
+     token: ENV["GITHUB_TOKEN_2"],
+     role: :default,
+   )
+   user_1 = User.create(
+     email: 'paulmdebevec@gmail.com',
+     first_name: 'Paul',
+     last_name: 'Debevec',
+     password: 'password_2',
+     login: 'PaulDebevec',
+     token: ENV["GITHUB_TOKEN_1"],
+     role: :default,
+   )
+
+    user3 = create(:user)
+    user3.token = "No Key"
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user_1)
+
+    visit(dashboard_path)
+
+    within '.followers' do
+      expect(page).to have_link("Add as Friend")
+      click_link("Add as Friend")
+    end
+
+    expect(page).to have_content("Successfully Added Friend!")
+    expect(user_1.friends.length).to eq(1)
+    expect(current_path).to eq(dashboard_path)
+  end
+  it "cannot add a friend that you are already friends with" do
     user_2 = User.create(
      email: 'fredrondina96@gmail.com',
      first_name: 'Fred',
@@ -28,10 +64,13 @@ describe 'User' do
 
     visit(dashboard_path)
     expect(page).to have_link("Add as Friend")
-    click_link("Add as Friend")
 
-    expect(page).to have_content("Successfully Added Friend!")
-    expect(user_1.friends.length).to eq(1)
-    expect(current_path).to eq(dashboard_path)
+    within '.following' do
+      expect(page).to have_link("Add as Friend")
+      click_link("Add as Friend")
+    end
+
+    visit(dashboard_path)
+    expect(page).to_not have_link("Add as Friend")
   end
 end

--- a/spec/features/user/user_can_add_friends_from_followers_spec.rb
+++ b/spec/features/user/user_can_add_friends_from_followers_spec.rb
@@ -7,6 +7,7 @@ describe 'User' do
      first_name: 'Fred',
      last_name: 'Rondina',
      password: 'password_1',
+     login: 'fredrondina96',
      token: ENV["GITHUB_TOKEN_2"],
      role: :default,
    )
@@ -15,6 +16,7 @@ describe 'User' do
      first_name: 'Paul',
      last_name: 'Debevec',
      password: 'password_2',
+     login: 'PaulDebevec',
      token: ENV["GITHUB_TOKEN_1"],
      role: :default,
    )
@@ -25,8 +27,7 @@ describe 'User' do
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user_1)
 
     visit(dashboard_path)
-
     expect(page).to have_link("Add as Friend")
-
+    click_link("Add as Friend")
   end
 end

--- a/spec/features/user/user_can_add_friends_from_followers_spec.rb
+++ b/spec/features/user/user_can_add_friends_from_followers_spec.rb
@@ -28,10 +28,10 @@ describe 'User' do
 
     visit(dashboard_path)
 
-    within '.followers' do
-      expect(page).to have_link("Add as Friend")
-      click_link("Add as Friend")
-    end
+      within '.followers' do
+        expect(page).to have_link("Add as Friend")
+        click_link("Add as Friend")
+      end
 
     expect(page).to have_content("Successfully Added Friend!")
     expect(user_1.friends.length).to eq(1)
@@ -65,12 +65,52 @@ describe 'User' do
     visit(dashboard_path)
     expect(page).to have_link("Add as Friend")
 
-    within '.following' do
-      expect(page).to have_link("Add as Friend")
-      click_link("Add as Friend")
-    end
+      within '.following' do
+        expect(page).to have_link("Add as Friend")
+        click_link("Add as Friend")
+      end
 
     visit(dashboard_path)
     expect(page).to_not have_link("Add as Friend")
+  end
+
+  it "added friends appear in a section on the dashboard" do
+    user_2 = User.create(
+     email: 'fredrondina96@gmail.com',
+     first_name: 'Fred',
+     last_name: 'Rondina',
+     password: 'password_1',
+     login: 'fredrondina96',
+     token: ENV["GITHUB_TOKEN_2"],
+     role: :default,
+   )
+   user_1 = User.create(
+     email: 'paulmdebevec@gmail.com',
+     first_name: 'Paul',
+     last_name: 'Debevec',
+     password: 'password_2',
+     login: 'PaulDebevec',
+     token: ENV["GITHUB_TOKEN_1"],
+     role: :default,
+   )
+
+    user3 = create(:user)
+    user3.token = "No Key"
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user_1)
+
+    visit(dashboard_path)
+    expect(page).to have_link("Add as Friend")
+
+      within '.following' do
+        expect(page).to have_link("Add as Friend")
+        click_link("Add as Friend")
+      end
+    expect(current_path).to eq(dashboard_path)
+
+      within '.my_friends' do
+        expect(page).to have_content("Fred Rondina")
+      end
+    save_and_open_page
   end
 end

--- a/spec/features/user/user_can_add_friends_from_followers_spec.rb
+++ b/spec/features/user/user_can_add_friends_from_followers_spec.rb
@@ -110,7 +110,7 @@ describe 'User' do
 
       within '.my_friends' do
         expect(page).to have_content("Fred Rondina")
+        expect(page).to have_content("fredrondina96")
       end
-    save_and_open_page
   end
 end

--- a/spec/features/user/user_can_add_friends_from_followers_spec.rb
+++ b/spec/features/user/user_can_add_friends_from_followers_spec.rb
@@ -30,7 +30,8 @@ describe 'User' do
     expect(page).to have_link("Add as Friend")
     click_link("Add as Friend")
 
-    expect(page).to have_content("Friend Added Succesfully")
-    expect(user1.friends.length).to eq(1)
+    expect(page).to have_content("Successfully Added Friend!")
+    expect(user_1.friends.length).to eq(1)
+    expect(current_path).to eq(dashboard_path)
   end
 end

--- a/spec/features/user/user_can_add_friends_from_followers_spec.rb
+++ b/spec/features/user/user_can_add_friends_from_followers_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+describe 'User' do
+  it 'user can sign in' do
+    user_2 = User.create(
+     email: 'fredrondina96@gmail.com',
+     first_name: 'Fred',
+     last_name: 'Rondina',
+     password: 'password_1',
+     token: ENV["GITHUB_TOKEN_2"],
+     role: :default,
+   )
+   user_1 = User.create(
+     email: 'paulmdebevec@gmail.com',
+     first_name: 'Paul',
+     last_name: 'Debevec',
+     password: 'password_2',
+     token: ENV["GITHUB_TOKEN_1"],
+     role: :default,
+   )
+
+    user3 = create(:user)
+    user3.token = "No Key"
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user_1)
+
+    visit(dashboard_path)
+
+    expect(page).to have_link("Add as Friend")
+
+  end
+end

--- a/spec/models/friend_spec.rb
+++ b/spec/models/friend_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe Friend, type: :model do
+  describe 'relationships' do
+    it { should belong_to :user }
+    it { should belong_to :user_friend }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe User, type: :model do
 
   describe 'relationships' do
     it { should have_many(:user_videos).dependent(:destroy)}
+    it { should have_many :friends }
+    it { should have_many(:user_friends).through(:friends) }
   end
 
   describe 'roles' do


### PR DESCRIPTION
Added all friends functionality. Github connected users can now add friends that are also github connected users, be they followers or following. Link to add a friend is dynamic, only appearing for people that are valid to be users friend (they have a github verified account, and they are not already friends). There is also a section at the bottom of the dashboard that appears only to those with friends, and lists all their friends names and GH handles. 